### PR TITLE
encode query using percent-encoding

### DIFF
--- a/apps/airquality/lib/airquality/sources/open_aq/measurements.ex
+++ b/apps/airquality/lib/airquality/sources/open_aq/measurements.ex
@@ -39,6 +39,8 @@ defmodule Airquality.Sources.OpenAQ.Measurements do
   end
 
   defp query_open_aq(identifier) do
+    identifier = URI.encode(identifier)
+
     url =
       "#{Application.get_env(:airquality, :open_aq_api_endpoint)}/latest?location=#{identifier}"
 


### PR DESCRIPTION
encodes whitespace as `%20` 
Httpoison used `+`