### PR TITLE
camelize attribute names

### DIFF
--- a/apps/airquality_web/config/config.exs
+++ b/apps/airquality_web/config/config.exs
@@ -32,6 +32,9 @@ config :mime, :types, %{
   "application/vnd.api+json" => ["json-api"]
 }
 
+config :ja_serializer, key_format: {:custom, JsonApiKeys, :camelize, :underscore}
+config :ja_serializer, type_format: {:custom, JsonApiKeys, :camelize}
+
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
   environment_name: Mix.env(),

--- a/apps/airquality_web/lib/airquality_web/json_api_keys.ex
+++ b/apps/airquality_web/lib/airquality_web/json_api_keys.ex
@@ -1,0 +1,14 @@
+defmodule JsonApiKeys do
+  def camelize(key) do
+    {first, rest} =
+      Phoenix.Naming.camelize(key)
+      |> String.split_at(1)
+
+    String.downcase(first) <> rest
+  end
+
+  def underscore(key) do
+    Phoenix.Naming.underscore(key)
+    |> String.downcase()
+  end
+end

--- a/apps/airquality_web/test/airquality_web/controllers/location_controller_test.exs
+++ b/apps/airquality_web/test/airquality_web/controllers/location_controller_test.exs
@@ -25,7 +25,7 @@ defmodule AirqualityWeb.LocationControllerTest do
                      "city" => "test-city",
                      "coordinates" => [10.0, 20.0],
                      "country" => "test-country",
-                     "last-updated" => "2019-01-01T00:00:00.000000Z"
+                     "lastUpdated" => "2019-01-01T00:00:00.000000Z"
                    },
                    "relationships" => %{
                      "measurements" => %{
@@ -56,7 +56,7 @@ defmodule AirqualityWeb.LocationControllerTest do
                      "city" => "test-city",
                      "coordinates" => [10.0, 20.0],
                      "country" => "test-country",
-                     "last-updated" => "2019-01-01T00:00:00.000000Z"
+                     "lastUpdated" => "2019-01-01T00:00:00.000000Z"
                    },
                    "relationships" => %{
                      "measurements" => %{
@@ -91,7 +91,7 @@ defmodule AirqualityWeb.LocationControllerTest do
                      "city" => "test-city",
                      "coordinates" => [10.0, 20.0],
                      "country" => "test-country",
-                     "last-updated" => "2019-01-01T00:00:00.000000Z"
+                     "lastUpdated" => "2019-01-01T00:00:00.000000Z"
                    },
                    "relationships" => %{
                      "measurements" => %{
@@ -109,9 +109,9 @@ defmodule AirqualityWeb.LocationControllerTest do
                "included" => [
                  %{
                    "attributes" => %{
-                     "measured-at" => "2019-01-01T00:00:00.000000Z",
+                     "measuredAt" => "2019-01-01T00:00:00.000000Z",
                      "parameter" => "pm10",
-                     "quality-index" => "very_low",
+                     "qualityIndex" => "very_low",
                      "unit" => "micro_grams_m3",
                      "value" => 0.0
                    },
@@ -143,7 +143,7 @@ defmodule AirqualityWeb.LocationControllerTest do
                    "city" => "test-city",
                    "coordinates" => [10.0, 20.0],
                    "country" => "test-country",
-                   "last-updated" => "2019-01-01T00:00:00.000000Z"
+                   "lastUpdated" => "2019-01-01T00:00:00.000000Z"
                  },
                  "relationships" => %{
                    "measurements" => %{
@@ -174,7 +174,7 @@ defmodule AirqualityWeb.LocationControllerTest do
                    "city" => "test-city",
                    "coordinates" => [10.0, 20.0],
                    "country" => "test-country",
-                   "last-updated" => "2019-01-01T00:00:00.000000Z"
+                   "lastUpdated" => "2019-01-01T00:00:00.000000Z"
                  },
                  "relationships" => %{
                    "measurements" => %{
@@ -191,9 +191,9 @@ defmodule AirqualityWeb.LocationControllerTest do
                "included" => [
                  %{
                    "attributes" => %{
-                     "measured-at" => "2019-01-01T00:00:00.000000Z",
+                     "measuredAt" => "2019-01-01T00:00:00.000000Z",
                      "parameter" => "pm10",
-                     "quality-index" => "very_low",
+                     "qualityIndex" => "very_low",
                      "unit" => "micro_grams_m3",
                      "value" => 0.0
                    },

--- a/apps/airquality_web/test/airquality_web/controllers/measurement_controller_test.exs
+++ b/apps/airquality_web/test/airquality_web/controllers/measurement_controller_test.exs
@@ -24,8 +24,8 @@ defmodule AirqualityWeb.MeasurementControllerTest do
                  %{
                    "attributes" => %{
                      "parameter" => "pm10",
-                     "measured-at" => "2019-01-01T00:00:00.000000Z",
-                     "quality-index" => "very_low",
+                     "measuredAt" => "2019-01-01T00:00:00.000000Z",
+                     "qualityIndex" => "very_low",
                      "unit" => "micro_grams_m3",
                      "value" => 0.0
                    },


### PR DESCRIPTION
closes #70 

There's only one open issue with this - apparently this capitalizes the type names in the response and I couldn't figure out why. To me that looks like a bug in JASerializer 😞 