### PR TITLE
add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+.env


### PR DESCRIPTION
So we can use .env file to store API keys accessible via `System.get_env()` for dev.

Use `$ source .env` in terminal tab to use api keys in .env file.
