### PR TITLE
use only identifier as remote ID

### DIFF
--- a/apps/breethe/lib/breethe/data/data.ex
+++ b/apps/breethe/lib/breethe/data/data.ex
@@ -8,9 +8,9 @@ defmodule Breethe.Data do
     |> preload_measurements()
   end
 
-  defp find_location(params) do
+  defp find_location_by_identifier(identifier) do
     Location
-    |> Repo.get_by(Map.take(params, [:city, :coordinates, :identifier, :country]))
+    |> Repo.get_by(identifier: identifier)
     |> Repo.preload(:measurements)
   end
 
@@ -34,7 +34,7 @@ defmodule Breethe.Data do
   end
 
   def create_location(params) do
-    case find_location(params) do
+    case find_location_by_identifier(params.identifier) do
       nil -> %Location{}
       location -> location
     end

--- a/apps/breethe/test/breethe/data/data_test.exs
+++ b/apps/breethe/test/breethe/data/data_test.exs
@@ -156,7 +156,7 @@ defmodule Breethe.DataTest do
 
     test "updates if location already exists" do
       params = params_for(:location, last_updated: DateTime.utc_now())
-      location = insert(:location, %{identifier: params.identifier})
+      location = insert(:location, %{identifier: params.identifier, city: "a different city"})
 
       updated_location = Data.create_location(params)
 


### PR DESCRIPTION
closes #86 

We are currently using `[:city, :coordinates, :identifier, :country]` to check whether we have a location in the DB already which means that whenever `city`, `coordinates` or `country` of a location changes we will generate the error in #86. The identifier alone should be sufficient and prevent that error.