### PR TITLE
[WIP] modify sentry config

### DIFF
--- a/apps/breethe/lib/breethe/application.ex
+++ b/apps/breethe/lib/breethe/application.ex
@@ -12,6 +12,8 @@ defmodule Breethe.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    :ok = :error_logger.add_report_handler(Sentry.Logger)
+
     Supervisor.start_link(
       [
         supervisor(Breethe.Repo, []),

--- a/apps/breethe/mix.exs
+++ b/apps/breethe/mix.exs
@@ -23,7 +23,7 @@ defmodule Breethe.Mixfile do
   def application do
     [
       mod: {Breethe.Application, []},
-      extra_applications: [:logger, :runtime_tools, :httpoison]
+      extra_applications: [:logger, :runtime_tools, :httpoison, :sentry]
     ]
   end
 
@@ -45,7 +45,8 @@ defmodule Breethe.Mixfile do
       {:bypass, "~> 0.8", only: :test},
       {:poison, "~> 3.1"},
       {:timex, "~> 3.1"},
-      {:mox, "~> 0.3", only: :test}
+      {:mox, "~> 0.3", only: :test},
+      {:sentry, "~> 6.2.1"}
     ]
   end
 

--- a/apps/breethe_web/config/config.exs
+++ b/apps/breethe_web/config/config.exs
@@ -37,13 +37,6 @@ config :ja_serializer, type_format: {:custom, JsonApiKeys, :camelize}
 
 config :cors_plug, origin: ["https://breethe.app", "http://dev.breethe.app"]
 
-config :sentry,
-  dsn: System.get_env("SENTRY_DSN"),
-  environment_name: Mix.env(),
-  enable_source_code_context: true,
-  root_source_code_path: File.cwd!(),
-  included_environments: [:prod]
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/breethe_web/lib/breethe_web/application.ex
+++ b/apps/breethe_web/lib/breethe_web/application.ex
@@ -12,6 +12,8 @@ defmodule BreetheWeb.Application do
       # worker(BreetheWeb.Worker, [arg1, arg2, arg3]),
     ]
 
+    :ok = :error_logger.add_report_handler(Sentry.Logger)
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: BreetheWeb.Supervisor]

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,13 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :sentry,
+  dsn: System.get_env("SENTRY_DSN"),
+  environment_name: Mix.env(),
+  enable_source_code_context: true,
+  root_source_code_path: File.cwd!(),
+  included_environments: [:prod, :dev]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
closes #53 
Error reporting for async tasks may require the use of `Sentry.capture_exception/2`