### PR TITLE
change dev domain to dev.breethe

### DIFF
--- a/apps/breethe_web/config/config.exs
+++ b/apps/breethe_web/config/config.exs
@@ -35,7 +35,7 @@ config :mime, :types, %{
 config :ja_serializer, key_format: {:custom, JsonApiKeys, :camelize, :underscore}
 config :ja_serializer, type_format: {:custom, JsonApiKeys, :camelize}
 
-config :cors_plug, origin: ["https://breethe.app", "http://dev.breethe.app"]
+config :cors_plug, origin: ["https://breethe.app", "https://dev.breethe"]
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),


### PR DESCRIPTION
Chrome enforces HSTS for the `.app` TLD which causes problems with self-signed certs. Using dev.breethe for local development should be much more convenient.