### PR TITLE
fix OpenAQ query

### DIFF
--- a/apps/breethe/lib/breethe/sources/open_aq/locations.ex
+++ b/apps/breethe/lib/breethe/sources/open_aq/locations.ex
@@ -43,7 +43,7 @@ defmodule Breethe.Sources.OpenAQ.Locations do
 
   defp query_open_aq(lat, lon) do
     url =
-      "#{Application.get_env(:breethe, :open_aq_api_endpoint)}/locations?coordinates=#{lat},#{lon}&nearest=10"
+      "#{Application.get_env(:breethe, :open_aq_api_endpoint)}/locations?coordinates=#{lat},#{lon}&order_by=distance&limit=10"
 
     {:ok, response} = HTTPoison.get(url)
     %{"results" => results} = Jason.decode!(response.body)

--- a/apps/breethe/test/breethe/sources/open_aq_test.exs
+++ b/apps/breethe/test/breethe/sources/open_aq_test.exs
@@ -99,7 +99,7 @@ defmodule Breethe.Sources.OpenAQTest do
   describe "load location data on demand:" do
     test "by latitude and longitude", %{bypass: bypass} do
       Bypass.expect(bypass, "GET", "/open-aq/locations", fn conn ->
-        assert %{"nearest" => "10", "coordinates" => "10,20"} ==
+        assert %{"order_by" => "distance", "limit" => "10", "coordinates" => "10,20"} ==
                  URI.decode_query(conn.query_string)
 
         Plug.Conn.resp(conn, 200, Jason.encode!(@sample_location))
@@ -143,7 +143,7 @@ defmodule Breethe.Sources.OpenAQTest do
       end)
 
       Bypass.expect(bypass, "GET", "/open-aq/locations", fn conn ->
-        assert %{"nearest" => "10", "coordinates" => "10,20"} ==
+        assert %{"order_by" => "distance", "limit" => "10", "coordinates" => "10,20"} ==
                  URI.decode_query(conn.query_string)
 
         Plug.Conn.resp(conn, 200, Jason.encode!(@sample_location))
@@ -182,7 +182,7 @@ defmodule Breethe.Sources.OpenAQTest do
       end)
 
       Bypass.expect(bypass, "GET", "/open-aq/locations", fn conn ->
-        assert %{"nearest" => "10", "coordinates" => "10,20"} ==
+        assert %{"order_by" => "distance", "limit" => "10", "coordinates" => "10,20"} ==
                  URI.decode_query(conn.query_string)
 
         Plug.Conn.resp(conn, 200, Jason.encode!(@sample_location))


### PR DESCRIPTION
updates the OpenAQ query: replaces `nearest=10` with `order_by=distance` and `limit=10` 