### PR TITLE
Increase search radius to 10km

### DIFF
--- a/apps/breethe/lib/breethe/data.ex
+++ b/apps/breethe/lib/breethe/data.ex
@@ -18,7 +18,7 @@ defmodule Breethe.Data do
 
   def find_locations(lat, lon) do
     Location
-    |> Location.within_meters(lat, lon, 1000)
+    |> Location.within_meters(lat, lon, 10000)
     |> Location.closest_first(lat, lon)
     |> Location.first_ten()
     |> Repo.all()

--- a/apps/breethe/lib/breethe/data/location.ex
+++ b/apps/breethe/lib/breethe/data/location.ex
@@ -42,10 +42,10 @@ defmodule Breethe.Data.Location do
     |> unique_constraint(:identifier)
   end
 
-  def within_meters(query, lat, lon, 1000) do
+  def within_meters(query, lat, lon, distance) do
     search_term = geo_from_coordinates(lat, lon)
 
-    from(l in query, where: st_dwithin_in_meters(l.coordinates, ^search_term, 1000))
+    from(l in query, where: st_dwithin_in_meters(l.coordinates, ^search_term, ^distance))
   end
 
   def closest_first(query, lat, lon) do


### PR DESCRIPTION
Return results within 10 km of the coordinates used for a search in the DB. Old value of 1km would lead to poor search results.