### PR TITLE
Optimize import

### DIFF
--- a/apps/breethe/lib/breethe/sources/eea/csv.ex
+++ b/apps/breethe/lib/breethe/sources/eea/csv.ex
@@ -11,32 +11,32 @@ defmodule Breethe.Sources.EEA.CSV do
   defp parse_csv(data) do
     data
     |> NimbleCSV.parse_string()
-    |> Stream.map(fn [
-                       network_countrycode,
-                       network_localid,
-                       network_name,
-                       network_namespace,
-                       network_timezone,
-                       pollutant,
-                       samplingpoint_localid,
-                       samplingpoint_namespace,
-                       samplingpoint_x,
-                       samplingpoint_y,
-                       coordsys,
-                       station_code,
-                       station_localid,
-                       station_name,
-                       station_namespace,
-                       value_datetime_begin,
-                       value_datetime_end,
-                       value_datetime_inserted,
-                       _value_datetime_updated,
-                       value_numeric,
-                       value_validity,
-                       value_verification,
-                       station_altitude,
-                       value_unit
-                     ] ->
+    |> Enum.map(fn [
+                     network_countrycode,
+                     network_localid,
+                     network_name,
+                     network_namespace,
+                     network_timezone,
+                     pollutant,
+                     samplingpoint_localid,
+                     samplingpoint_namespace,
+                     samplingpoint_x,
+                     samplingpoint_y,
+                     coordsys,
+                     station_code,
+                     station_localid,
+                     station_name,
+                     station_namespace,
+                     value_datetime_begin,
+                     value_datetime_end,
+                     value_datetime_inserted,
+                     _value_datetime_updated,
+                     value_numeric,
+                     value_validity,
+                     value_verification,
+                     station_altitude,
+                     value_unit
+                   ] ->
       %{
         network_countrycode: network_countrycode,
         network_localid: network_localid,
@@ -67,12 +67,11 @@ defmodule Breethe.Sources.EEA.CSV do
     end)
   end
 
-  defp store_data(stream) do
-    stream
+  defp store_data(data) do
+    data
     |> Enum.filter(fn datum -> datum.value_numeric != "" end)
     |> Enum.group_by(&Map.get(&1, :station_code))
-    |> Stream.map(&store_station/1)
-    |> Stream.run()
+    |> Enum.map(&store_station/1)
   end
 
   defp store_station(station_data) do
@@ -88,11 +87,15 @@ defmodule Breethe.Sources.EEA.CSV do
       |> extract_location()
       |> Data.create_location()
 
-    _measurement =
+    measurements_params =
       sorted_mesaurements
-      |> extract_measurement()
-      |> Map.put_new(:location_id, location.id)
-      |> Data.create_measurement()
+      |> Enum.uniq_by(& &1.value_datetime_updated)
+      |> Enum.map(&extract_measurement/1)
+      |> Enum.map(fn measurement_params ->
+        Map.put_new(measurement_params, :location_id, location.id)
+      end)
+
+    Data.create_measurements(measurements_params)
   end
 
   defp extract_location(datum) do

--- a/apps/breethe/lib/breethe/sources/eea/csv.ex
+++ b/apps/breethe/lib/breethe/sources/eea/csv.ex
@@ -95,7 +95,7 @@ defmodule Breethe.Sources.EEA.CSV do
         Map.put_new(measurement_params, :location_id, location.id)
       end)
 
-    Data.create_measurements(measurements_params)
+    Data.import_measurements(location, measurements_params)
   end
 
   defp extract_location(datum) do

--- a/apps/breethe/lib/mix/tasks/sync_data.ex
+++ b/apps/breethe/lib/mix/tasks/sync_data.ex
@@ -8,6 +8,15 @@ defmodule Mix.Tasks.SyncData do
   @impl Mix.Task
   def run(_args) do
     Mix.Task.run("app.start")
-    EEA.get_data()
+
+    failed_imports =
+      EEA.get_data()
+      |> Enum.flat_map(fn result -> [result] end)
+      |> Enum.filter(&match?({:error, _}, &1))
+
+    case length(failed_imports) do
+      0 -> Mix.shell().info("Updated successfully")
+      _ -> Mix.shell().error("Some updates failed")
+    end
   end
 end


### PR DESCRIPTION
The import was a bit slow previously and took forever to run. This optimizes it by doing a bunch of things:

* only touch every location once and update it with the value from the latest measurement
* filter only new measurements and insert those, ignoring potential updates to old measurements