### PR TITLE
Task for cleaning old data

### DIFF
--- a/apps/breethe/lib/mix/tasks/clean_old_data.ex
+++ b/apps/breethe/lib/mix/tasks/clean_old_data.ex
@@ -1,0 +1,16 @@
+defmodule Mix.Tasks.CleanOldData do
+  use Mix.Task
+
+  alias Breethe.Data
+
+  @shortdoc "Cleans up old European data"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    Data.delete_old_data(3)
+
+    Mix.shell().info("Dropped old data successfully")
+  end
+end

--- a/apps/breethe/priv/repo/migrations/20200610153230_add_measurement_time_index.exs
+++ b/apps/breethe/priv/repo/migrations/20200610153230_add_measurement_time_index.exs
@@ -1,0 +1,7 @@
+defmodule Breethe.Repo.Migrations.AddMeasurementTimeIndex do
+  use Ecto.Migration
+
+  def change do
+    create index("measurements", [:measured_at])
+  end
+end

--- a/apps/breethe/test/breethe/data/data_test.exs
+++ b/apps/breethe/test/breethe/data/data_test.exs
@@ -176,4 +176,44 @@ defmodule Breethe.DataTest do
       assert Repo.aggregate(Measurement, :count) == 2
     end
   end
+
+  describe "delete_old_data" do
+    test "deletes measurements older than the threshold" do
+      location = insert(:location)
+
+      insert(:measurement,
+        location: location,
+        measured_at: DateTime.utc_now()
+      )
+
+      insert(:measurement,
+        location: location,
+        measured_at: Timex.shift(DateTime.utc_now(), days: -4)
+      )
+
+      Data.delete_old_data(3)
+
+      assert Repo.aggregate(Measurement, :count) == 1
+    end
+
+    test "deletes locations that do not have measurements" do
+      empty_location = insert(:location)
+      location = insert(:location)
+      old_location = insert(:location)
+
+      insert(:measurement,
+        location: location,
+        measured_at: DateTime.utc_now()
+      )
+
+      insert(:measurement,
+        location: old_location,
+        measured_at: Timex.shift(DateTime.utc_now(), days: -4)
+      )
+
+      Data.delete_old_data(3)
+
+      assert Repo.aggregate(Location, :count) == 1
+    end
+  end
 end


### PR DESCRIPTION
This adds a mix task for cleaning old data so that we don't grow our DB endlessly – data older than a few days should not be relevant and this task drops it.